### PR TITLE
fix: remove deprecated tilde ~

### DIFF
--- a/.changeset/sweet-pears-argue.md
+++ b/.changeset/sweet-pears-argue.md
@@ -1,0 +1,5 @@
+---
+'@llamaindex/pdf-viewer': minor
+---
+
+fix: remove deprecated tilde ~

--- a/src/view/index.css
+++ b/src/view/index.css
@@ -1,5 +1,5 @@
-@import '~react-pdf/dist/esm/Page/AnnotationLayer.css';
-@import '~react-pdf/dist/esm/Page/TextLayer.css';
+@import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
+@import 'react-pdf/dist/esm/Page/TextLayer.css';
 
 .pdf-viewer-container {
   display: flex;


### PR DESCRIPTION
`postcss-import` doesn’t support tilde `~` -> caused this error in chat-ui:
```
Error: Can't resolve '~react-pdf/dist/esm/Page/AnnotationLayer.css' in 'C:\...\chat-ui\node_modules\.pnpm\@llamaindex+pdf-viewer...
```
Webpack and PostCSS now resolve css import node_modules automatically without needing ~.